### PR TITLE
修正など

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -15,4 +15,14 @@ return [
 
     // base url
     'url' => env('BASE_URL', 'http://localhost'),
+
+    // routing
+    'routing' => [
+
+        // routing match types
+        'match-types' => [
+            // 'id' => '[0-9]+',
+        ],
+    ],
+
 ];

--- a/src/Kernel/Loader/RoutingLoader.php
+++ b/src/Kernel/Loader/RoutingLoader.php
@@ -66,11 +66,18 @@ final class RoutingLoader implements LoaderContract
         $this->app->container->singleton(
             RouterFactoryContract::class,
             function (ContainerContract $container): RouterFactoryContract {
+                /** @var ConfigRepositoryContract */
+                $repository = $container->make(ConfigRepositoryContract::class);
+
+                /** @var array<string,string> */
+                $matchTypes = $repository->get('app.routing.match-types', []);
+
                 /** @var URLSetting */
                 $setting = $container->make(URLSetting::class);
 
                 return new AltoRouterFactory(
                     baseURL: $setting->url(),
+                    matchTypes: $matchTypes,
                 );
             },
         );

--- a/src/Support/Injector/ArgumentResolvers.php
+++ b/src/Support/Injector/ArgumentResolvers.php
@@ -5,6 +5,8 @@ namespace Takemo101\Egg\Support\Injector;
 use ReflectionParameter;
 use Takemo101\Egg\Support\Injector\ArgumentResolverContract;
 use Takemo101\Egg\Support\Injector\ContainerContract;
+use Takemo101\Egg\Support\Injector\Resolver\ArgumentNameResolver;
+use Takemo101\Egg\Support\Injector\Resolver\DefaultResolver;
 
 /**
  * 引数の解決処理コレクション
@@ -53,5 +55,18 @@ final class ArgumentResolvers
         }
 
         return $arguments;
+    }
+
+    /**
+     * デフォルトの引数解決処理を返す
+     *
+     * @return self
+     */
+    public static function default(): self
+    {
+        return new self(
+            new DefaultResolver(),
+            new ArgumentNameResolver(),
+        );
     }
 }

--- a/src/Support/Injector/Container.php
+++ b/src/Support/Injector/Container.php
@@ -47,10 +47,7 @@ class Container implements ContainerContract
     ) {
         $this->filters = $filters ?? new DefinitionDataFilters();
 
-        $resolvers ??= new ArgumentResolvers(
-            new DefaultResolver(),
-            new ArgumentNameResolver(),
-        );
+        $resolvers ??= ArgumentResolvers::default();
 
         $this->callableResolver = new CallableResolver(
             container: $this,

--- a/src/Support/Shared/CallableCreator.php
+++ b/src/Support/Shared/CallableCreator.php
@@ -3,6 +3,7 @@
 namespace Takemo101\Egg\Support\Shared;
 
 use RuntimeException;
+use Takemo101\Egg\Routing\Shared\Handler;
 use Takemo101\Egg\Support\Injector\ContainerContract;
 use Takemo101\Egg\Support\Shared\Functional;
 
@@ -44,14 +45,14 @@ final class CallableCreator
         if ($function->isArray()) {
             $array = $function->toArray();
 
-            return $this->checkCallable($array);
+            return $this->arrayToCallable($array);
         }
 
         if ($function->isString()) {
             $object = $this->container->make($function->toString());
 
             if (!is_object($object)) {
-                throw new RuntimeException('error! invalid callable string');
+                throw new RuntimeException('error: invalid callable string!');
             }
 
             return $this->objectToCallable($object);
@@ -59,6 +60,37 @@ final class CallableCreator
 
         return $this->checkCallable($function->callable);
     }
+
+    /**
+     * 配列からコールバックを作成する
+     *
+     * @param mixed[] $array
+     * @return callable
+     * @throws RuntimeException
+     */
+    private function arrayToCallable(array $array): callable
+    {
+        if (is_callable($array)) {
+            return $array;
+        }
+
+        $first = $array[0] ?? throw new RuntimeException('error: array is empty!');
+
+        if (is_string($first)) {
+            $first = $this->container->make($first);
+        }
+
+        if (!is_object($first)) {
+            throw new RuntimeException('error: invalid callable array!');
+        }
+
+        if ($second = $array[1] ?? false) {
+            return $this->checkCallable([$first, $second]);
+        }
+
+        return $this->objectToCallable($first);
+    }
+
 
     /**
      * オブジェクトからコールバックを作成する
@@ -83,7 +115,7 @@ final class CallableCreator
             }
         }
 
-        throw new RuntimeException('error! invalid callable object');
+        throw new RuntimeException('error: invalid callable object!');
     }
 
     /**
@@ -99,6 +131,6 @@ final class CallableCreator
             return $callable;
         }
 
-        throw new RuntimeException('error! invalid callable');
+        throw new RuntimeException('error: invalid callable!');
     }
 }

--- a/test/Support/CallableCreatorTest.php
+++ b/test/Support/CallableCreatorTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Test\Support;
+
+use PHPUnit\Framework\TestCase;
+use Takemo101\Egg\Routing\Shared\Handler;
+use Takemo101\Egg\Support\Injector\Container;
+use Takemo101\Egg\Support\Shared\CallableCreator;
+
+/**
+ * callable creator test
+ */
+class CallableCreatorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function クラス名とメソッド名からなる配列からCallableを生成__OK()
+    {
+        $container = new Container();
+
+        $creator = new CallableCreator(
+            $container,
+        );
+
+        $callable = $creator->create(new Handler([TestController::class, 'index']));
+
+        $data = $container->call($callable);
+
+        $this->assertEquals(
+            TestController::$data,
+            $data,
+            '配列からCallableを生成＆実行して値を取得できる',
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function クラス名のみの配列からCallableを生成__OK()
+    {
+        $container = new Container();
+
+        $creator = new CallableCreator(
+            $container,
+        );
+
+        $callable = $creator->create(new Handler([TestController::class]));
+
+        $data = $container->call($callable);
+
+        $this->assertEquals(
+            TestController::$data,
+            $data,
+            '配列からCallableを生成＆実行して値を取得できる',
+        );
+    }
+}
+
+class TestController
+{
+    public static string $data = 'test';
+
+    public function index()
+    {
+        return self::$data;
+    }
+
+    public function __invoke()
+    {
+        return self::$data;
+    }
+}


### PR DESCRIPTION
## 概要
CallableCreatorで、配列でのコールバック指定ができてない部分があったので修正した。
ついでに、ルーティングのマッチタイプ配列を``` config/app.php ``` で設定できるようにした。

## 実装内容
1. CallableCreatorの修正
2. CallableCreatorのテスト追加
3. AltoRouterFactoryのDI時に、マッチタイプを``` config/app.php ``` から取得できるように変更