### PR TITLE
DIコンテナのaliasの動作を変更

### DIFF
--- a/src/Http/Filter/SessionFilter.php
+++ b/src/Http/Filter/SessionFilter.php
@@ -59,7 +59,8 @@ class SessionFilter
      */
     private function register(Session $session): void
     {
-        $this->app->container->instance(Session::class, $session);
-        $this->app->container->alias(Session::class, 'session');
+        $this->app->container
+            ->alias(Session::class, 'session')
+            ->instance(Session::class, $session);
     }
 }

--- a/src/Http/HttpDispatcher.php
+++ b/src/Http/HttpDispatcher.php
@@ -103,22 +103,24 @@ final class HttpDispatcher implements HttpDispatcherContract
         Request $request,
         Response $response,
     ): void {
-        $this->container->instance(
-            Request::class,
-            $request,
-        );
-        $this->container->alias(
-            Request::class,
-            'request',
-        );
+        $this->container
+            ->alias(
+                Request::class,
+                'request',
+            )
+            ->instance(
+                Request::class,
+                $request,
+            );
 
-        $this->container->instance(
-            Response::class,
-            $response,
-        );
-        $this->container->alias(
-            Response::class,
-            'response',
-        );
+        $this->container
+            ->alias(
+                Response::class,
+                'response',
+            )
+            ->instance(
+                Response::class,
+                $response,
+            );
     }
 }

--- a/src/Support/Hook/Hook.php
+++ b/src/Support/Hook/Hook.php
@@ -144,7 +144,6 @@ final class Hook
 
                 call_user_func_array(
                     $callable,
-                    // フィルタ出力がnullの場合は初期パラメータを渡す
                     [$parameter],
                 );
             }

--- a/src/Support/Injector/ContainerContract.php
+++ b/src/Support/Injector/ContainerContract.php
@@ -11,10 +11,12 @@ interface ContainerContract
 {
     /**
      * 別名の設定
+     * instanceで別名を設定する場合は、
+     * instanceよりも先に設定する必要がある
      *
      * @param string $class
      * @param string $alias
-     * @return mixed
+     * @return self
      */
     public function alias(string $class, string $alias);
 
@@ -23,7 +25,7 @@ interface ContainerContract
      *
      * @param string $label
      * @param mixed $instance
-     * @return mixed
+     * @return self
      */
     public function instance(string $label, mixed $instance);
 
@@ -32,7 +34,7 @@ interface ContainerContract
      *
      * @param string $label
      * @param Closure|string|null $callback
-     * @return mixed
+     * @return self
      */
     public function singleton(string $label, Closure|string|null $callback = null);
 
@@ -41,7 +43,7 @@ interface ContainerContract
      *
      * @param string $label
      * @param Closure|string|null $callback
-     * @return mixed
+     * @return self
      */
     public function bind(string $label, Closure|string|null $callback = null);
 
@@ -56,7 +58,7 @@ interface ContainerContract
     /**
      * 全てのバインディングを開放
      *
-     * @return mixed
+     * @return self
      */
     public function clear();
 

--- a/src/Support/Injector/Definition.php
+++ b/src/Support/Injector/Definition.php
@@ -4,7 +4,6 @@ namespace Takemo101\Egg\Support\Injector;
 
 use Closure;
 use Error;
-use RuntimeException;
 
 /**
  * 依存注入するための定義

--- a/src/Support/Injector/DefinitionDataFilters.php
+++ b/src/Support/Injector/DefinitionDataFilters.php
@@ -5,7 +5,7 @@ namespace Takemo101\Egg\Support\Injector;
 /**
  * 依存注入定義の解決時のフィルタ処理コレクション
  */
-final class DefinitionDataFilters implements DefinitionDataFilterContract
+final class DefinitionDataFilters
 {
     /**
      * @var DefinitionDataFilterContract[]
@@ -39,24 +39,27 @@ final class DefinitionDataFilters implements DefinitionDataFilterContract
      * 依存注入定義の解決時に
      * 定義されたデータをフィルタ処理する
      *
-     * @param string $label
+     * @param DefinitionLabels $labels
      * @param DefinitionContract $definition
      * @param mixed $data
      * @return mixed
      */
     public function filter(
-        string $label,
+        DefinitionLabels $labels,
         DefinitionContract $definition,
         mixed $data,
     ) {
         $result = $data;
 
-        foreach ($this->filters as $filter) {
-            $result = $filter->filter(
-                label: $label,
-                definition: $definition,
-                data: $result,
-            );
+        // ラベル毎にフィルタ処理を行う
+        foreach ($labels->labels as $label) {
+            foreach ($this->filters as $filter) {
+                $result = $filter->filter(
+                    label: $label,
+                    definition: $definition,
+                    data: $result,
+                );
+            }
         }
 
         return $result;

--- a/src/Support/Injector/DefinitionLabels.php
+++ b/src/Support/Injector/DefinitionLabels.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Takemo101\Egg\Support\Injector;
+
+/**
+ * 依存定義のラベルコレクション
+ */
+final class DefinitionLabels
+{
+    /**
+     * @var string[]
+     */
+    public readonly array $labels;
+
+    public function __construct(
+        string ...$labels,
+    ) {
+        $this->labels = array_unique($labels);
+    }
+
+    /**
+     * ラベルを追加する
+     *
+     * @param string ...$labels
+     * @return self
+     */
+    public function add(string ...$labels): self
+    {
+        return new self(...[
+            ...$this->labels,
+            ...$labels,
+        ]);
+    }
+
+    /**
+     * ラベルを削除する
+     *
+     * @param string ...$labels
+     * @return self
+     */
+    public function remove(string ...$labels): self
+    {
+        foreach ($labels as $search) {
+            foreach ($this->labels as $index => $label) {
+                if ($search === $label) {
+                    unset($this->labels[$index]);
+                }
+            }
+        }
+
+        return $this;
+    }
+}


### PR DESCRIPTION
## 概要
DIコンテナのaliasでmakeを実行しても、hook処理が実行されていなかったので、DIコンテナでのalias処理を変更しました。

## 実装内容
1. Containerクラスでのaliasの振る舞いを変更
2. Containerクラス上でclass名に対して、どれだけの別名を持つか？というデータを追加
3. 2. のためのデータクラスDefinitionLabelsクラスを追加
4. hookのテストコード追加