### PR TITLE
hookの重複実行修正

### DIFF
--- a/src/Support/Hook/Hook.php
+++ b/src/Support/Hook/Hook.php
@@ -37,7 +37,14 @@ final class Hook
         object|array|string $function,
         int $priority = HookFilter::DefaultPriority,
     ): self {
-        if (!isset($this->filters[$tag])) {
+        if (isset($this->filters[$tag])) {
+            $this->filters[$tag]->add(
+                HookFilter::fromCallable(
+                    priority: $priority,
+                    function: $function,
+                ),
+            );
+        } else {
             $this->filters[$tag] = new HookFilters(
                 HookFilter::fromCallable(
                     priority: $priority,
@@ -45,13 +52,6 @@ final class Hook
                 ),
             );
         }
-
-        $this->filters[$tag]->add(
-            HookFilter::fromCallable(
-                priority: $priority,
-                function: $function,
-            ),
-        );
 
         return $this;
     }
@@ -108,8 +108,8 @@ final class Hook
 
         $filters = $this->filters[$tag];
 
-        foreach ($filters->filters as $filter) {
-            foreach ($filter->actions as $action) {
+        foreach ($filters->all() as $filter) {
+            foreach ($filter->actions() as $action) {
                 $callable = $this->creator->create($action->function);
 
                 $result = call_user_func_array(
@@ -138,8 +138,8 @@ final class Hook
 
         $filters = $this->filters[$tag];
 
-        foreach ($filters->filters as $filter) {
-            foreach ($filter->actions as $action) {
+        foreach ($filters->all() as $filter) {
+            foreach ($filter->actions() as $action) {
                 $callable = $this->creator->create($action->function);
 
                 call_user_func_array(

--- a/src/Support/Hook/HookFilter.php
+++ b/src/Support/Hook/HookFilter.php
@@ -20,7 +20,7 @@ final class HookFilter
     /**
      * @var array<string,HookAction>
      */
-    public array $actions = [];
+    private array $actions = [];
 
     /**
      * constructor
@@ -29,10 +29,33 @@ final class HookFilter
      * @param HookAction ...$actions
      */
     public function __construct(
-        public readonly int $priority = self::DefaultPriority,
+        private int $priority = self::DefaultPriority,
         HookAction ...$actions,
     ) {
         $this->add(...$actions);
+    }
+
+    /**
+     * 優先度の調整
+     * 引数に与えた配列に優先度が含まれている場合は、
+     * 含まれてない優先度に調整するために、
+     * 優先度をインクリメントしていく
+     *
+     * @param array<integer,mixed> $array 基準となる配列
+     * @return integer
+     */
+    public function adjustPriority(array $array): int
+    {
+        $priority = $this->priority;
+
+        while (true) {
+            if (!isset($array[$priority])) {
+                break;
+            }
+            $priority++;
+        }
+
+        return $this->priority = $priority;
     }
 
     /**
@@ -75,6 +98,26 @@ final class HookFilter
         $this->actions = [];
 
         return $this;
+    }
+
+    /**
+     * getter
+     *
+     * @return integer
+     */
+    public function priority(): int
+    {
+        return $this->priority;
+    }
+
+    /**
+     * getter
+     *
+     * @return array<string,HookAction>
+     */
+    public function actions(): array
+    {
+        return $this->actions;
     }
 
     /**

--- a/src/Support/Hook/HookFilters.php
+++ b/src/Support/Hook/HookFilters.php
@@ -11,7 +11,7 @@ final class HookFilters
     /**
      * @var array<integer,HookFilter>
      */
-    public array $filters = [];
+    private array $filters = [];
 
     /**
      * constructor
@@ -33,7 +33,9 @@ final class HookFilters
     public function add(HookFilter ...$filters): self
     {
         foreach ($filters as $filter) {
-            $this->filters[$filter->priority] = $filter;
+            $priority = $filter->adjustPriority($this->filters);
+
+            $this->filters[$priority] = $filter;
         }
 
         ksort($this->filters);


### PR DESCRIPTION
## 概要
hookの優先度関連でバグがあったので修正しました。

## 実装内容
1. hook処理が同じ優先度で登録される場合は、優先度がインクリメントされるようにした
2. hook処理が重複実行されていたのを修正